### PR TITLE
chore: displays categories carousel dynamicaly

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,11 +1,44 @@
-import ProductSection from "@/components/ProductSection";
+import ProductSection from "@/components/ProductSection"
+
+interface CategoryResponse {
+  categories: {
+    id: string
+    name: string
+    description: string
+    createdAt: Date
+    updatedAt: Date
+  }[]
+}
+
+interface Category {
+  value: string
+  name: string
+}
 
 export default async function Home() {
+  const response = await fetch(`${process.env.NEXT_PUBLIC_APP_URL}/api/categories`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    next: { revalidate: 30 }
+  })
+
+  let categories: Category[] = []
+  if (response.ok) {
+    const { categories: receivedCategories } = await response.json() as CategoryResponse
+    const categoriesFormatted = receivedCategories.map(category => ({
+      value: category.name.toLowerCase(),
+      name: category.name
+    }))
+    categories = categoriesFormatted
+  }
 
   return (
     <main className="flex-1 flex flex-col items-center justify-start gap-8 mt-8 px-8">
-      <ProductSection section="Highlights" category="highlights" />
-      <ProductSection section="Clothes" category="clothes" />
+      {categories.map((category) => (
+        <ProductSection key={category.value} section={category.name} category={category.value} />
+      ))}
     </main>
   )
 }

--- a/src/components/ProductSection/index.tsx
+++ b/src/components/ProductSection/index.tsx
@@ -3,8 +3,15 @@ import ProductCarousel from "../ProductCarousel"
 import Stripe from "stripe";
 
 interface ProductSectionProps {
-  section: string;
-  category: string;
+  section: string
+  category: string
+}
+
+interface Product {
+  id: string
+  name: string
+  imageUrl: string
+  price: string
 }
 
 export default async function ProductSection({ section, category }: ProductSectionProps) {
@@ -16,16 +23,21 @@ export default async function ProductSection({ section, category }: ProductSecti
     next: { revalidate: 30 }
   })
 
-  let products = []
+  let products: Product[] = []
   if (response.ok) {
     const { products: receivedProducts } = await response.json()
     products = receivedProducts
   }
 
   return (
-    <section className="keen-slider max-w-[1280px] flex-col gap-4">
-      <h1 className="text-zinc-50 text-4xl">{section.toUpperCase()}</h1>
-      <ProductCarousel products={products} />
-    </section>
+    products.length > 0 ?
+      (
+        <section className="keen-slider max-w-[1280px] flex-col gap-4">
+          <h1 className="text-zinc-50 text-4xl">{section.toUpperCase()}</h1>
+          <ProductCarousel products={products} />
+        </section>
+      )
+      :
+      <></>
   )
 }


### PR DESCRIPTION
# Description

Since now, there were two categories beeing shown in first page (Highlights and Clothes), but it was not representing the real categories stored in dabase/stripe. This change configures first page to search categories from database and mount carousels from it.